### PR TITLE
Prevent `runMorris()` crash with `LogNormalDistribution` at quantile boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ inst/doc
 /doc/
 /Meta/
 /docs
+/wip

--- a/R/sampling-functions.R
+++ b/R/sampling-functions.R
@@ -40,7 +40,7 @@ getLogNormalSampleVector <- function(quantileVec, mean, CV) {
   sigmaSquared <- log((CV^2) + 1)
   mu <- log(mean) - (sigmaSquared / 2)
   sigma <- sqrt(sigmaSquared)
-  logSpaceQuantileVec <- getNormalSampleVector(quantileVec, mean = mu, stdv = sigma, truncate = FALSE)
+  logSpaceQuantileVec <- getNormalSampleVector(quantileVec, mean = mu, stdv = sigma, truncate = TRUE)
   return(exp(logSpaceQuantileVec))
 }
 

--- a/tests/testthat/test-sampling-functions.R
+++ b/tests/testthat/test-sampling-functions.R
@@ -1,0 +1,23 @@
+# Hematocrit distribution from GitHub issue #20
+hematocritMean <- 0.47
+hematocritCV <- 0.0646
+
+test_that("getLogNormalSampleVector returns finite, positive values at quantile boundaries 0 and 1", {
+  samples <- getLogNormalSampleVector(
+    c(0, 1),
+    mean = hematocritMean,
+    CV = hematocritCV
+  )
+
+  expect_true(all(is.finite(samples)))
+  expect_true(all(samples > 0))
+})
+
+test_that("getLogNormalSampleVector returns the distribution median at quantile 0.5", {
+  median <- hematocritMean / sqrt(hematocritCV^2 + 1)
+
+  expect_equal(
+    getLogNormalSampleVector(0.5, mean = hematocritMean, CV = hematocritCV),
+    median
+  )
+})


### PR DESCRIPTION
Closes #20

Root cause (re-verified): The Morris trajectory grid in `getTrajectory()` emits quantiles that span exactly 0 and 1. `getLogNormalSampleVector()` called `getNormalSampleVector(..., truncate = FALSE)`, so `qnorm(0) = -Inf` and `qnorm(1) = +Inf`, and `exp()` collapsed those to 0 and Inf setting the parameter to 0/Inf and crashing the simulation. NormalDistribution was unaffected because getNormalSampleVector() defaults to `truncate = TRUE`; `UniformDistribution` maps linearly to finite endpoints.

Design decision: Simple fix at the distribution level rather than the trajectory level. Truncating in `getTrajectory()` would alter sampling for every distribution (including the currently-correct Uniform path), a larger, riskier change. Making the LogNormal path mirror the Normal path (which already truncates to the 2.5-97.5% range) is minimal and consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced log-normal sampling to reliably produce finite, strictly positive values across all quantile boundaries.
* **Tests**
  * Added test coverage for log-normal sampling, validating boundary conditions and distribution accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->